### PR TITLE
Add fixtures for tests

### DIFF
--- a/Swift-Fixtures-Example.xcodeproj/project.pbxproj
+++ b/Swift-Fixtures-Example.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3F7D98F22168BF3200746D76 /* Swift_Fixtures_Example.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F7D98E42168BF3100746D76 /* Swift_Fixtures_Example.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3F7D98FC2168C15000746D76 /* Pizza.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7D98FB2168C15000746D76 /* Pizza.swift */; };
 		3F7D98FE2168C32A00746D76 /* PizzaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7D98FD2168C32A00746D76 /* PizzaTests.swift */; };
+		3F7D99002168C42300746D76 /* Pizza+Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7D98FF2168C42300746D76 /* Pizza+Fixture.swift */; };
 		3F7D99022168C5E200746D76 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7D99012168C5E200746D76 /* Address.swift */; };
 		3F7D99042168C63800746D76 /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7D99032168C63800746D76 /* Order.swift */; };
 		3F7D99062168C67C00746D76 /* Beverage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7D99052168C67C00746D76 /* Beverage.swift */; };
@@ -35,6 +36,7 @@
 		3F7D98F12168BF3200746D76 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3F7D98FB2168C15000746D76 /* Pizza.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pizza.swift; sourceTree = "<group>"; };
 		3F7D98FD2168C32A00746D76 /* PizzaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PizzaTests.swift; sourceTree = "<group>"; };
+		3F7D98FF2168C42300746D76 /* Pizza+Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Pizza+Fixture.swift"; sourceTree = "<group>"; };
 		3F7D99012168C5E200746D76 /* Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
 		3F7D99032168C63800746D76 /* Order.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Order.swift; sourceTree = "<group>"; };
 		3F7D99052168C67C00746D76 /* Beverage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Beverage.swift; sourceTree = "<group>"; };
@@ -98,6 +100,7 @@
 			children = (
 				3F7D98F12168BF3200746D76 /* Info.plist */,
 				3F7D99072168C6F800746D76 /* OrderTests.swift */,
+				3F7D98FF2168C42300746D76 /* Pizza+Fixture.swift */,
 				3F7D98FD2168C32A00746D76 /* PizzaTests.swift */,
 			);
 			path = "Swift-Fixtures-ExampleTests";
@@ -225,6 +228,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F7D99082168C6F800746D76 /* OrderTests.swift in Sources */,
+				3F7D99002168C42300746D76 /* Pizza+Fixture.swift in Sources */,
 				3F7D98FE2168C32A00746D76 /* PizzaTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Swift-Fixtures-Example.xcodeproj/project.pbxproj
+++ b/Swift-Fixtures-Example.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		3F7D99042168C63800746D76 /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7D99032168C63800746D76 /* Order.swift */; };
 		3F7D99062168C67C00746D76 /* Beverage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7D99052168C67C00746D76 /* Beverage.swift */; };
 		3F7D99082168C6F800746D76 /* OrderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7D99072168C6F800746D76 /* OrderTests.swift */; };
+		3F7D990C2168C95300746D76 /* Order+Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7D990B2168C95300746D76 /* Order+Fixture.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,6 +42,7 @@
 		3F7D99032168C63800746D76 /* Order.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Order.swift; sourceTree = "<group>"; };
 		3F7D99052168C67C00746D76 /* Beverage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Beverage.swift; sourceTree = "<group>"; };
 		3F7D99072168C6F800746D76 /* OrderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTests.swift; sourceTree = "<group>"; };
+		3F7D990B2168C95300746D76 /* Order+Fixture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Order+Fixture.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,6 +100,7 @@
 		3F7D98EE2168BF3200746D76 /* Swift-Fixtures-ExampleTests */ = {
 			isa = PBXGroup;
 			children = (
+				3F7D990B2168C95300746D76 /* Order+Fixture.swift */,
 				3F7D98F12168BF3200746D76 /* Info.plist */,
 				3F7D99072168C6F800746D76 /* OrderTests.swift */,
 				3F7D98FF2168C42300746D76 /* Pizza+Fixture.swift */,
@@ -227,6 +230,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F7D990C2168C95300746D76 /* Order+Fixture.swift in Sources */,
 				3F7D99082168C6F800746D76 /* OrderTests.swift in Sources */,
 				3F7D99002168C42300746D76 /* Pizza+Fixture.swift in Sources */,
 				3F7D98FE2168C32A00746D76 /* PizzaTests.swift in Sources */,

--- a/Swift-Fixtures-ExampleTests/Order+Fixture.swift
+++ b/Swift-Fixtures-ExampleTests/Order+Fixture.swift
@@ -1,0 +1,26 @@
+//
+//  Order+Fixture.swift
+//  Swift-Fixtures-ExampleTests
+//
+//  Created by Gio on 6/10/18.
+//  Copyright © 2018 mokacoding. All rights reserved.
+//
+
+@testable import Swift_Fixtures_Example
+
+extension Order {
+
+  static func fixture(
+    pizzas: [Pizza] = [.fixture()],
+    drinks: [Beverage] = [Water()],
+    address: Address = Address(
+      street: "1 Infinity Loop",
+      tow: "Cupertino",
+      state: "California",
+      postCode: "95014",
+      country: "USA"
+    )
+  ) -> Order {
+    return Order(pizzas: pizzas, drinks: drinks, address: address)
+  }
+}

--- a/Swift-Fixtures-ExampleTests/OrderTests.swift
+++ b/Swift-Fixtures-ExampleTests/OrderTests.swift
@@ -12,20 +12,7 @@ import XCTest
 class OrderTests: XCTestCase {
 
   func testItemsCount() {
-    let pizza = Pizza(
-      name: "Margherita",
-      toppings: [TomatoSauce(), Mozzarella(), Salami(extraSpicy: true)]
-    )
-    let deliveryAddress = Address(
-      street: "1 Infinity Loop",
-      tow: "Cupertino",
-      state: "California",
-      postCode: "95014",
-      country: "USA"
-    )
-    let drinks = [Water()]
-
-    let order = Order(pizzas: [pizza], drinks: drinks, address: deliveryAddress)
+    let order = Order.fixture(pizzas: [.fixture()], drinks: [Water()])
 
     XCTAssertEqual(order.itemsCount, 2)
   }

--- a/Swift-Fixtures-ExampleTests/Pizza+Fixture.swift
+++ b/Swift-Fixtures-ExampleTests/Pizza+Fixture.swift
@@ -1,0 +1,19 @@
+//
+//  Pizza+Fixture.swift
+//  Swift-Fixtures-ExampleTests
+//
+//  Created by Gio on 6/10/18.
+//  Copyright © 2018 mokacoding. All rights reserved.
+//
+
+@testable import Swift_Fixtures_Example
+
+extension Pizza {
+
+  static func fixture(
+    name: String = "name",
+    toppings: [Topping] = [TomatoSauce(), Mozzarella()]
+  ) -> Pizza {
+    return Pizza(name: name, toppings: toppings)
+  }
+}

--- a/Swift-Fixtures-ExampleTests/PizzaTests.swift
+++ b/Swift-Fixtures-ExampleTests/PizzaTests.swift
@@ -12,13 +12,13 @@ import XCTest
 class PizzaTests: XCTestCase {
 
   func testIsVegetarianWithVegetarianToppings() {
-    let pizza = Pizza(name: "name", toppings: [TomatoSauce(), Mozzarella()])
+    let pizza = Pizza.fixture(toppings: [TomatoSauce(), Mozzarella()])
 
     XCTAssertTrue(pizza.isVegeterian)
   }
 
   func testIsVegetarianWithNonVegetarianToppings() {
-    let pizza = Pizza(name: "name", toppings: [TomatoSauce(), Mozzarella(), Salami(extraSpicy: true)])
+    let pizza = Pizza.fixture(toppings: [TomatoSauce(), Mozzarella(), Salami(extraSpicy: true)])
 
     XCTAssertFalse(pizza.isVegeterian)
   }


### PR DESCRIPTION
Adds the `fixture` extension to `Pizza` and `Order`. Notice the cleanup in the tests, now they are focused only on the values that have an effect on the behaviour.